### PR TITLE
Fix duplicate rows and document UTF‑8 option

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ pip install pandas chardet
 python fm_converter.py --long long.csv --short short.csv
 ```
 
+Use the `--utf8` flag if your text editor cannot display Big‑5 encoded
+Chinese characters.
+
 The script will prompt for the constant parameters (PLAN_NO, BRANCH_CODE,
 etc.) and create one or more `FM.txt` files in the `output/` directory by
 default.

--- a/fm_converter.py
+++ b/fm_converter.py
@@ -229,7 +229,10 @@ def convert(
         if old in merged.columns:
             merged.rename(columns={old: new}, inplace=True)
     # Drop any other duplicate-suffixed columns to avoid confusion
+
     merged = merged[[c for c in merged.columns if not c.endswith(("_x", "_y"))]]
+    # Ensure one record per patient
+    merged.drop_duplicates(subset="身分證號", inplace=True)
 
     # Sort by ID for deterministic output
     merged.sort_values("身分證號", inplace=True)


### PR DESCRIPTION
## Summary
- deduplicate merged rows by ID before building records
- mention `--utf8` in README so users know how to get UTF‑8 output

## Testing
- `python -m py_compile fm_converter.py fm_converter_gui.py`

------
https://chatgpt.com/codex/tasks/task_e_6842c8d9ef3c8324a1c2aa4d84055b85