### PR TITLE
Fix MacRoman garbled text

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ python fm_converter.py --long long.csv --short short.csv
 Use the `--utf8` flag if your text editor cannot display Big‑5 encoded
 Chinese characters.
 
+If the CSV files were accidentally decoded in MacRoman (common on macOS), the
+converter will now try to recover the original Big‑5 text automatically.
+
 The script will prompt for the constant parameters (PLAN_NO, BRANCH_CODE,
 etc.) and create one or more `FM.txt` files in the `output/` directory by
 default.


### PR DESCRIPTION
## Summary
- handle MacRoman-encoded garbage in `_fw`
- document automatic recovery in README

## Testing
- `python fm_converter.py --help | head -n 20`
- `python - <<'PY'
from fm_converter import _fw, BIG5
s = "洪文樸"
bad = s.encode('big5').decode('macroman')
print('bad:', bad)
print('decoded:', _fw(bad, 12, enc=BIG5).decode('big5'))
PY`

------
https://chatgpt.com/codex/tasks/task_e_6842e6d032008324990f280642ac3ac1