### PR TITLE
Refactor to default UTF‑8 with optional Big‑5 output

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,26 +11,22 @@ Two interfaces are provided:
 
 * Python 3.10+
 * `pandas`
-* `chardet`
 * `tkinter` (bundled with Python)
 
 Install dependencies with:
 
 ```bash
-pip install pandas chardet
+pip install pandas
 ```
 
 ## Command line usage
 
 ```bash
-python fm_converter.py --long long.csv --short short.csv
+python fm_converter.py --long long.csv --short short.csv [--big5]
 ```
 
-Use the `--utf8` flag if your text editor cannot display Big‑5 encoded
-Chinese characters.
-
-If the CSV files were accidentally decoded in MacRoman (common on macOS), the
-converter will now try to recover the original Big‑5 text automatically.
+All input CSV files must be UTF‑8 encoded. The output `FM.txt` will be UTF‑8 by
+default; pass `--big5` to generate Big‑5 encoded output instead.
 
 The script will prompt for the constant parameters (PLAN_NO, BRANCH_CODE,
 etc.) and create one or more `FM.txt` files in the `output/` directory by
@@ -45,7 +41,7 @@ python fm_converter_gui.py
 ```
 
 The GUI allows you to select the input files and output directory using file
-dialogs.
+dialogs. Enable the **Big‑5 Output** checkbox if you need legacy encoding.
 
 ### Building an executable
 

--- a/fm_converter_gui.py
+++ b/fm_converter_gui.py
@@ -57,9 +57,9 @@ class ConverterGUI:
         tk.Entry(root, textvariable=self.out_var, width=40).grid(row=8, column=1)
         tk.Button(root, text="Browse", command=self.browse_outdir).grid(row=8, column=2)
 
-        # UTF-8 checkbox
-        self.utf8_var = tk.BooleanVar()
-        tk.Checkbutton(root, text="UTF-8 Output", variable=self.utf8_var).grid(row=9, column=1, sticky="w")
+        # Big-5 checkbox
+        self.big5_var = tk.BooleanVar()
+        tk.Checkbutton(root, text="Big-5 Output", variable=self.big5_var).grid(row=9, column=1, sticky="w")
 
         # Convert button
         tk.Button(root, text="Convert", command=self.convert).grid(row=10, column=1, pady=10)
@@ -93,7 +93,7 @@ class ConverterGUI:
                 fixed,
                 self.month_var.get(),
                 int(self.seq_var.get() or 1),
-                out_encoding="utf-8" if self.utf8_var.get() else fm_converter.BIG5,
+                out_encoding=fm_converter.BIG5 if self.big5_var.get() else fm_converter.ENCODING,
                 outdir=Path(self.out_var.get()),
             )
             messagebox.showinfo("Success", "Conversion completed")


### PR DESCRIPTION
## Summary
- make UTF‑8 the default encoding but add `--big5` flag
- restore Big‑5 output option in the GUI
- document optional Big‑5 output and checkbox

## Testing
- `python -m py_compile fm_converter.py fm_converter_gui.py`
- `python fm_converter.py -h`

------
https://chatgpt.com/codex/tasks/task_e_6842f4b5c9f883249221940f2f8602e4